### PR TITLE
chore: bump package versions to 1.0.0-alpha.1 for main and Rust packages

### DIFF
--- a/crates/binding/package.json
+++ b/crates/binding/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperse/hps-code-checker-rust",
   "homepage": "https://github.com/hyperse-io/hps-code-checker-plugin",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/hyperse-io/hps-code-checker-plugin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@hyperse/hps-code-checker-rspack-plugin",
-  "version": "1.0.0-alpha.0",
-  "private": true,
+  "version": "1.0.0-alpha.1",
   "description": "The HPS Code Checker Plugin.",
   "keywords": [
     "hyperse",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 1.0.0-alpha.1.
  * Prepared the package for publication by removing the private restriction, enabling distribution via the package registry.
  * No functional changes or public API modifications; existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->